### PR TITLE
Source ~/.zshrc after homebrew install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -55,4 +55,4 @@ source $HOME/.brewconfig.zsh
 rehash
 brew update
 
-echo "\nPlease open a new shell to finish installation"
+source ~/.zshrc


### PR DESCRIPTION
Plutôt que de relancer un nouveau shell il suffit de ressourcer zsh. A tester, je suis pas à l'ecole mais normalement c'est ce que j'ai fais hier.