### PR TITLE
keep the locks on the same drive

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,20 +25,6 @@ export HOMEBREW_TEMP=/tmp/\$USER/Homebrew/Temp
 
 mkdir -p \$HOMEBREW_CACHE
 mkdir -p \$HOMEBREW_TEMP
-
-HOMEBREW_LOCKS_TARGET=/tmp/\$USER/Homebrew/Locks
-HOMEBREW_LOCKS_FOLDER=\$HOME/.brew/var/homebrew
-
-mkdir -p \$HOMEBREW_LOCKS_TARGET
-mkdir -p \$HOMEBREW_LOCKS_FOLDER
-
-# Symlink to Locks target folders
-# If not already a symlink
-if ! [[ -L \$HOMEBREW_LOCKS_FOLDER && -d \$HOMEBREW_LOCKS_FOLDER ]]; then
-  echo "Creating symlink for Locks folder"
-  rm -rf \$HOMEBREW_LOCKS_FOLDER
-  ln -s \$HOMEBREW_LOCKS_TARGET \$HOMEBREW_LOCKS_FOLDER
-fi
 EOL
 
 # Add .brewconfig sourcing in your .zshrc if not already present


### PR DESCRIPTION
This fix the issue discussed [here](https://forum.intra.42.fr/topics/927/messages?page=2#53702).
Following is an example of the bug:
``` sh
$ brew install gpg
Error: You must `brew link pkg-config` before gnupg2 can be installed
$ brew link pkg-config
Linking /Users/ypringau/.brew/Cellar/pkg-config/0.29.1_2... 2 symlinks created
$ brew install gpg
Error: You must `brew link pkg-config` before gnupg2 can be installed
```
It seems it came from the fact that symlinking between drives (here `/Users/$USER` and `/`) doesn't work. I don't know what was the reason behind doing this, but removing this part of the script solve the issue.